### PR TITLE
Update Redis rpush key to use MAC address dynamically

### DIFF
--- a/app/core/handlers/sensors/handler.py
+++ b/app/core/handlers/sensors/handler.py
@@ -18,7 +18,7 @@ class SensorDataHandler:
             telemetry = TelemetryData.from_payload(mac_address, payload)
 
             self.db.save(asdict(telemetry))
-            self.redis_client.rpush("telemetry_queue", json.dumps(asdict(telemetry)))
+            self.redis_client.rpush(str(mac_address), json.dumps(asdict(telemetry)))
 
             self.logger.info(f"Telemetry data saved: {telemetry}")
 


### PR DESCRIPTION
Previously, telemetry data was pushed to a static "telemetry_queue" key in Redis. Now, the MAC address is used dynamically as the key, improving data organization and making it easier to track device-specific telemetry. This change enhances the granularity of the stored data.