### PR TITLE
Log telemetry data before saving to Redis and database

### DIFF
--- a/app/core/handlers/sensors/handler.py
+++ b/app/core/handlers/sensors/handler.py
@@ -17,9 +17,10 @@ class SensorDataHandler:
             mac_address = variables[0]
             telemetry = TelemetryData.from_payload(mac_address, payload)
 
-            self.db.save(asdict(telemetry))
-            self.redis_client.rpush(str(mac_address), json.dumps(asdict(telemetry)))
 
+            print(str(mac_address), json.dumps(asdict(telemetry)))
+            self.redis_client.rpush(str(mac_address), json.dumps(asdict(telemetry)))
+            # self.db.save(asdict(telemetry))
             self.logger.info(f"Telemetry data saved: {telemetry}")
 
         except ValueError as e:


### PR DESCRIPTION
Added a print statement to log the MAC address and telemetry data in JSON format before saving to Redis and the database. This helps in debugging and verifying the data flow through the handler.